### PR TITLE
Update playlist.py

### DIFF
--- a/src/models/playlist.py
+++ b/src/models/playlist.py
@@ -276,10 +276,12 @@ class Database(QObject):
 
         contentCache = []
         if os.path.exists(PLAYLIST_CACHE_FILE):
-            with open(PLAYLIST_CACHE_FILE) as _file:
+            with open(PLAYLIST_CACHE_FILE, "r+") as _file:
                 _cache = _file.read()
-                contentCache = json.loads(_cache)
-
+                try:
+                    contentCache = json.loads(_cache)
+                except ValueError:
+                    _file.truncate()
         if len(contentCache) == queryResults.count():
             return json.dumps(contentCache)
         else:


### PR DESCRIPTION
解决deepin-movie播放器在加载~/.config/deepin-movie目录下播放列表文件playlist.cache损害导致的json解析异常抛出没有捕获处理导致的播放器无法启动问题。
出错原因，播放器打开情况下系统异常导致重启。播放器在写入播放列表文件时没有写全导致该文件不是合法的json文件。
解决途径：当播放器加载json格式的播放列表文件时，如果解析异常会抛出ValueError异常，捕获该异常，并将该错误文件清空即可。
异常方式：打开~/.config/deepin-movie目录，修改playlist.cache文件，让其变成不合法的json文件，再次打开播放器，会发现播放器无法启动。terminal启动播放器会发现详细异常信息。